### PR TITLE
Fix data-loss, crash, and false-signal bugs from code review

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -99,8 +99,20 @@ try:
     port = int(port or 22)
 except ValueError:
     port = 22
+# Merge into any existing settings.json: only the "backup" key is ours to set.
+# A blind overwrite here would wipe other keys the app stores in this same file
+# (e.g. retroachievements.web_api_key) whenever onboarding / --config re-runs.
+data = {}
+try:
+    with open(out) as f:
+        loaded = json.load(f)
+    if isinstance(loaded, dict):
+        data = loaded
+except (OSError, ValueError):
+    data = {}
+data["backup"] = {"host": host, "port": port, "user": user, "dest": dest}
 with open(out, "w") as f:
-    json.dump({"backup": {"host": host, "port": port, "user": user, "dest": dest}}, f, indent=2)
+    json.dump(data, f, indent=2)
 PY
   say "Wrote ${STATE}/settings.json"
 }

--- a/tests/selftest.py
+++ b/tests/selftest.py
@@ -147,7 +147,7 @@ def test_backup(tmp: Path) -> None:
     everything = backup.tier_sources("everything")
     check("everything = 2 legs (userdata excl roms + roms), mirrors the cron",
           len(everything) == 2 and everything[0].rel == "" and everything[0].dest_name == "userdata"
-          and "roms/" in everything[0].excludes and everything[1].dest_name == "roms")
+          and "/roms/" in everything[0].excludes and everything[1].dest_name == "roms")
 
     cmd = backup.build_rsync_command(small[0], dry_run=True, ud=ud, backup=bk)
     check("dry-run flag present", "--dry-run" in cmd)
@@ -164,6 +164,22 @@ def test_backup(tmp: Path) -> None:
     check("media exclude rendered", any(a == "--exclude=media/" for a in rcmd))
     check("medium roms -> roms/ dir under the configured dest",
           rcmd[-1] == "root@backup.example:/backups/batocera/roms/")
+
+    # The dest runs in the REMOTE shell (via --rsync-path), so a dest with a
+    # space or shell metacharacter must be quoted, never word-split or executed.
+    spaced = {"host": "h", "port": 22, "user": "root", "dest": "/mnt/Volume 1/backups"}
+    scmd = backup.build_rsync_command(small[0], ud=ud, backup=spaced)
+    rp = next(a for a in scmd if a.startswith("--rsync-path="))
+    check("rsync-path quotes a dest containing spaces",
+          "'/mnt/Volume 1/backups/userdata/saves'" in rp)
+    check("rsync-path never mkdir's the bare unquoted spaced path",
+          "mkdir -p /mnt/Volume 1/backups" not in rp)
+    evil = {"host": "h", "port": 22, "user": "root", "dest": "/x; rm -rf /y"}
+    ecmd = backup.build_rsync_command(small[0], ud=ud, backup=evil)
+    erp = next(a for a in ecmd if a.startswith("--rsync-path="))
+    check("rsync-path wraps an injected ';' inside a single-quoted string",
+          "'/x; rm -rf /y/userdata/saves'" in erp
+          and erp == "--rsync-path=mkdir -p '/x; rm -rf /y/userdata/saves' && rsync")
 
     check("progress parse 47%", backup.parse_progress("  1,234  47%  1.2MB/s  0:00:03") == 47)
     check("progress parse none", backup.parse_progress("sending incremental file list") is None)
@@ -287,6 +303,20 @@ def test_bios(tmp: Path) -> None:
     check("batocera_version reads first token", bios.batocera_version() == "43.1")
     check("batocera_version missing file -> unknown",
           bios.batocera_version(str(tmp / "nope.version")) == "unknown")
+
+    # run_check must RAISE (not return []) when the tool can't run, so a check
+    # that never happened is never rendered as a green "no problems".
+    os.environ["TOOLBOX_BIOS_CMD"] = str(tmp / "no-such-batocera-systems-bin")
+    raised = False
+    try:
+        bios.run_check()
+    except RuntimeError:
+        raised = True
+    finally:
+        os.environ.pop("TOOLBOX_BIOS_CMD", None)
+    check("run_check raises when the tool is missing (no false green)", raised)
+    check("run_check with injected text still returns parsed results",
+          len(bios.run_check(_BIOS_SAMPLE)) == 4)
 
 
 def test_restore(tmp: Path) -> None:
@@ -458,6 +488,14 @@ def test_library(tmp: Path) -> None:
           "./Streets (USA).md" in hidden)
     check("gamelist backup written before edit",
           any(c.name.startswith("gamelist.xml.bak-toolbox-") for c in gen.iterdir()))
+    check("gamelist write is atomic (no .tmp-toolbox left)",
+          not list(gen.glob("*.tmp-toolbox")))
+
+    # Convergence: after applying, a re-plan finds nothing to hide (the already-
+    # hidden variants are excluded), so the system reaches "already deduped"
+    # instead of re-listing the same copies forever.
+    sp2 = library.plan_system("genesis")
+    check("re-plan after apply has nothing left to hide", sp2.hide == [])
 
 
 def test_perf(tmp: Path) -> None:
@@ -658,6 +696,17 @@ def test_logs(tmp: Path) -> None:
     ll = logs.parse_last_launch(two)
     check("logs picks the last launch", ll.system == "n64" and ll.game == "B.z64")
 
+    # A ROM name with an apostrophe is emitted by Python's repr with DOUBLE
+    # quotes: PosixPath("Assassin's Creed.nes"). The launch must still parse
+    # (before, it was invisible and the card showed the previous game).
+    apos = ("2026 'gameStart', 'nes', 'libretro', 'fceumm', "
+            "PosixPath(\"/userdata/roms/nes/Assassin's Creed.nes\")]\n"
+            "2026 launch Exiting configgen with status 139\n")
+    ll = logs.parse_last_launch(apos)
+    check("logs parses a double-quoted PosixPath (apostrophe in name)",
+          ll is not None and ll.game == "Assassin's Creed.nes")
+    check("logs apostrophe-launch status parsed", ll.status == 139)
+
     stderr = ("evmapy: no process found\n"
               "2026 ERROR (foo.py:1):runCommand boom\n"
               "/x: No such file or directory\n")
@@ -708,6 +757,69 @@ def test_logs(tmp: Path) -> None:
     del os.environ["TOOLBOX_LOG_DIR"]
 
 
+def test_safe_writes(tmp: Path) -> None:
+    """The atomic + capped-backup + fail-loud-read invariants that keep a
+    transient read error or a power cut from wiping batocera.conf/gamelist."""
+    from toolbox.core import config, shaders
+    print("[safe_writes]")
+
+    conf = tmp / "sw" / "batocera.conf"
+    conf.parent.mkdir(parents=True, exist_ok=True)
+    os.environ["TOOLBOX_BATOCERA_CONF"] = str(conf)
+    try:
+        # absent conf reads as "" (a fresh cabinet), never an error
+        check("read_conf_text: absent -> ''", config.read_conf_text() == "")
+
+        conf.write_text("keep.this=1\nother=2\n", encoding="utf-8")
+        check("read_conf_text: present -> contents",
+              "keep.this=1" in config.read_conf_text())
+
+        # write is atomic (no temp left) and backs up the prior file
+        config.write_batocera_conf("keep.this=1\nother=3\n")
+        check("write_batocera_conf: content written",
+              "other=3" in conf.read_text(encoding="utf-8"))
+        check("write_batocera_conf: leaves no .tmp-toolbox",
+              not list(conf.parent.glob("*.tmp-toolbox")))
+        check("write_batocera_conf: backed up the old file",
+              any(p.name.startswith("batocera.conf.bak-toolbox-")
+                  for p in conf.parent.iterdir()))
+
+        # backups are capped at BACKUP_KEEP (the bug: perf/shaders/library used
+        # to never prune) -- exercise the shared helper directly.
+        for i in range(8):
+            (conf.parent / f"batocera.conf.bak-toolbox-2026010{i}-000000").write_text("x")
+        config.prune_backups(conf, keep=config.BACKUP_KEEP)
+        kept = list(conf.parent.glob("batocera.conf.bak-toolbox-*"))
+        check("prune caps conf backups at BACKUP_KEEP", len(kept) == config.BACKUP_KEEP)
+
+        # THE wipe guard: a present-but-unreadable conf must RAISE, not read "".
+        # Pointing the conf path at a directory makes read_text raise OSError
+        # deterministically on every platform.
+        baddir = tmp / "sw" / "confdir"
+        baddir.mkdir(parents=True, exist_ok=True)
+        os.environ["TOOLBOX_BATOCERA_CONF"] = str(baddir)
+        raised = False
+        try:
+            config.read_conf_text()
+        except OSError:
+            raised = True
+        check("read_conf_text raises on an unreadable (non-absent) conf", raised)
+
+        # set_renderer must inherit that: on a read failure it raises and writes
+        # NOTHING, rather than rewriting the conf down to one shader line.
+        before = sorted(p.name for p in baddir.iterdir())
+        raised = False
+        try:
+            shaders.set_renderer("snes", shaders.INHERIT)
+        except OSError:
+            raised = True
+        after = sorted(p.name for p in baddir.iterdir())
+        check("set_renderer raises instead of wiping when the conf won't read",
+              raised and before == after)
+    finally:
+        os.environ.pop("TOOLBOX_BATOCERA_CONF", None)
+
+
 def main() -> int:
     with tempfile.TemporaryDirectory() as d:
         tmp = Path(d)
@@ -726,6 +838,7 @@ def main() -> int:
         test_cheevos(tmp)
         test_portmeta(tmp)
         test_logs(tmp)
+        test_safe_writes(tmp)
     print(f"\n{PASS} OK, {FAIL} NO")
     return 1 if FAIL else 0
 

--- a/toolbox/__init__.py
+++ b/toolbox/__init__.py
@@ -1,7 +1,8 @@
 """Batocera Toolbox: a couch-friendly, gamepad-driven multi-tool Port.
 
-Three modules under one app: on-demand Backup (rsync to the NAS), a read-only
-ROM Audit dashboard, and a safe Shader picker. The `core` package is pure and
-headless-testable; `ui` is the pygame front-end.
+One app, many modules: Backup/Restore (rsync to the NAS), a read-only ROM Audit
+dashboard, a version-aware BIOS check, a safe Shader picker, 1G1R Library dedup,
+Performance toggles, RetroAchievements, and Crash Logs. The `core` package is
+pure and headless-testable; `ui` is the pygame front-end.
 """
 __version__ = "0.3.2"

--- a/toolbox/core/backup.py
+++ b/toolbox/core/backup.py
@@ -15,6 +15,7 @@ failure count, so a partial failure is never swallowed.
 from __future__ import annotations
 
 import re
+import shlex
 import subprocess
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -59,9 +60,12 @@ def tier_sources(tier: str) -> list[BackupSource]:
         ]
     if tier == "everything":
         # Exactly the scheduled job's two legs: /userdata (minus roms) ->
-        # userdata/, and /userdata/roms -> roms/.
+        # userdata/, and /userdata/roms -> roms/. The exclude is ANCHORED
+        # (leading slash) so it drops only /userdata/roms, not every dir named
+        # "roms" nested deeper (e.g. an emulator's own roms/ under system/) --
+        # those must stay in the "everything" leg or they'd be in no leg at all.
         return [
-            BackupSource("", "userdata", ["roms/"]),
+            BackupSource("", "userdata", ["/roms/"]),
             BackupSource("roms", "roms"),
         ]
     raise ValueError(f"unknown backup tier: {tier!r}")
@@ -99,8 +103,10 @@ def build_rsync_command(src: BackupSource, *, dry_run: bool = False,
         cmd.append(f"--exclude={e}")
     cmd += ["-e", f"ssh -p {backup['port']} -o StrictHostKeyChecking=accept-new"]
     # mkdir the full per-leg dest (it can be nested, e.g. userdata/system/configs)
-    # so a leg is self-sufficient even on a fresh NAS dataset.
-    cmd.append(f"--rsync-path=mkdir -p {remote_dir} && rsync")
+    # so a leg is self-sufficient even on a fresh NAS dataset. The dest is
+    # user-supplied and runs in the REMOTE shell here, so quote it: a path with a
+    # space would split into wrong dirs, and shell metacharacters would execute.
+    cmd.append(f"--rsync-path=mkdir -p {shlex.quote(remote_dir)} && rsync")
     # Trailing slash on source: copy its CONTENTS into the dest folder.
     cmd += [f"{src_path}/", remote]
     return cmd

--- a/toolbox/core/bios.py
+++ b/toolbox/core/bios.py
@@ -132,15 +132,20 @@ def batocera_version(path: str | None = None) -> str:
 def run_check(text: str | None = None) -> list[SystemBios]:
     """Run ``batocera-systems`` (or parse injected ``text``) into results.
 
-    Returns ``[]`` if the tool is missing or errors, so the UI can show an
-    empty state instead of crashing on a non-cabinet host.
+    RAISES ``RuntimeError`` if the tool is missing, times out, or exits non-zero.
+    A check that never ran must NOT look like a clean pass: an empty list here
+    means "ran, found no problems" (a real green), never "couldn't run".
     """
     if text is None:
         cmd = os.environ.get("TOOLBOX_BIOS_CMD", "batocera-systems")
         try:
             proc = subprocess.run([cmd], capture_output=True, text=True, timeout=120)
-        except (OSError, subprocess.SubprocessError):
-            return []
+        except (OSError, subprocess.SubprocessError) as e:
+            raise RuntimeError(f"couldn't run {cmd}: {e}") from e
+        if proc.returncode != 0:
+            detail = (proc.stderr or proc.stdout or "").strip().splitlines()
+            raise RuntimeError(f"{cmd} exited {proc.returncode}"
+                               + (f": {detail[-1]}" if detail else ""))
         text = proc.stdout or ""
     return parse_systems_output(text)
 

--- a/toolbox/core/config.py
+++ b/toolbox/core/config.py
@@ -6,8 +6,10 @@ the headless self-test can redirect them at a temp tree instead of the real
 """
 from __future__ import annotations
 
+import io
 import json
 import os
+import time
 from pathlib import Path
 
 
@@ -108,6 +110,77 @@ def backup_config() -> dict:
     cfg = dict(DEFAULT_BACKUP)
     cfg.update(load_settings().get("backup", {}))
     return cfg
+
+
+# --- Safe file writes (atomic + capped timestamped backups) ----------------
+# batocera.conf and gamelist.xml are read by the OS / EmulationStation at boot,
+# so every Toolbox edit backs the file up (timestamped, capped) and writes
+# atomically (temp + os.replace) to survive a mid-write power cut. These are the
+# single home for those rules; perf, shaders, library, and portmeta all use them
+# instead of hand-rolling their own backup/write.
+BACKUP_KEEP = 5
+
+
+def prune_backups(path, keep: int = BACKUP_KEEP) -> None:
+    """Keep only the newest `keep` `<name>.bak-toolbox-*` files beside `path`.
+
+    Backup names embed a sortable `YYYYMMDD-HHMMSS` stamp, so a name sort is
+    chronological; older copies beyond `keep` are removed.
+    """
+    p = Path(path)
+    baks = sorted(p.parent.glob(f"{p.name}.bak-toolbox-*"), key=lambda b: b.name)
+    for old in (baks[:-keep] if keep > 0 else baks):
+        old.unlink(missing_ok=True)
+
+
+def backup_file(path, keep: int = BACKUP_KEEP) -> None:
+    """Timestamped copy of an existing file, then prune to `keep`. No-op if absent."""
+    p = Path(path)
+    if not p.is_file():
+        return
+    ts = time.strftime("%Y%m%d-%H%M%S")
+    p.with_name(f"{p.name}.bak-toolbox-{ts}").write_bytes(p.read_bytes())
+    prune_backups(p, keep)
+
+
+def atomic_write_bytes(path, data: bytes) -> None:
+    """Write bytes via a temp sibling + os.replace, so `path` is never half-written."""
+    p = Path(path)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    tmp = p.with_name(f"{p.name}.tmp-toolbox")
+    tmp.write_bytes(data)
+    os.replace(tmp, p)
+
+
+def atomic_write_text(path, text: str, encoding: str = "utf-8") -> None:
+    """Atomic text write (see atomic_write_bytes)."""
+    atomic_write_bytes(path, text.encode(encoding))
+
+
+def atomic_write_tree(tree, path) -> None:
+    """Atomically write an ElementTree, so a crash can't truncate the gamelist ES
+    reads on boot."""
+    buf = io.BytesIO()
+    tree.write(buf, encoding="utf-8", xml_declaration=True)
+    atomic_write_bytes(path, buf.getvalue())
+
+
+def read_conf_text() -> str:
+    """Read batocera.conf. Returns '' ONLY for a genuinely absent file; a present
+    but unreadable file RAISES (OSError / UnicodeDecodeError). This is the fix for
+    the wipe bug: a failed read must never be mistaken for an empty conf and then
+    rewritten over the real one."""
+    p = batocera_conf()
+    if not p.exists():
+        return ""
+    return p.read_text(encoding="utf-8")
+
+
+def write_batocera_conf(text: str) -> None:
+    """Back up (capped) then atomically write batocera.conf."""
+    p = batocera_conf()
+    backup_file(p)
+    atomic_write_text(p, text)
 
 
 # --- Directory classification --------------------------------------------

--- a/toolbox/core/library.py
+++ b/toolbox/core/library.py
@@ -17,7 +17,6 @@ from __future__ import annotations
 
 import os
 import re
-import time
 import xml.etree.ElementTree as ET
 from dataclasses import dataclass, field
 
@@ -223,10 +222,17 @@ def eligible_systems() -> list:
 
 
 def plan_system(system: str) -> SystemPlan:
-    """Build the hide plan for one system (Favorites excluded from hiding)."""
+    """Build the hide plan for one system (Favorites excluded from hiding).
+
+    Winner selection sees ALL variants, but a variant that is ALREADY hidden is
+    left out of the plan: there is nothing to do for it. Without this, every
+    re-run re-lists the copies a previous apply already hid, so the system shows
+    "TO HIDE N" forever and never reaches the deduped state.
+    """
     gl = config.roms_dir() / system / "gamelist.xml"
     games = _read_games(gl) if gl.is_file() else []
     fav_paths = {pv for pv, fav, _ in games if fav}
+    hidden_paths = {pv for pv, _, hid in games if hid}
     groups = group_games([parse_name(pv) for pv, _, _ in games])
 
     hide: list = []
@@ -240,6 +246,8 @@ def plan_system(system: str) -> SystemPlan:
         for path in dec.hide:
             if path in fav_paths:
                 fav_protected += 1
+            elif path in hidden_paths:
+                continue                     # already hidden: nothing to do
             else:
                 hide.append(path)
     return SystemPlan(system=system, hide=hide, n_keep=len(games) - len(hide),
@@ -254,8 +262,9 @@ def apply_hides(system: str, paths: list) -> ApplyResult:
     tree = ET.parse(gl)
     root = tree.getroot()
 
-    ts = time.strftime("%Y%m%d-%H%M%S")
-    gl.with_name(f"gamelist.xml.bak-toolbox-{ts}").write_bytes(gl.read_bytes())
+    # Capped, timestamped backup before the edit (shared with portmeta/perf/
+    # shaders so the retention cap is enforced everywhere, not just portmeta).
+    config.backup_file(gl)
 
     res = ApplyResult()
     for g in root.findall("game"):
@@ -271,5 +280,7 @@ def apply_hides(system: str, paths: list) -> ApplyResult:
         h.text = "true"
         res.hidden += 1
 
-    tree.write(gl, encoding="utf-8", xml_declaration=True)
+    # Atomic write (temp + os.replace): a power cut can't leave EmulationStation
+    # a truncated gamelist to parse on boot.
+    config.atomic_write_tree(tree, gl)
     return res

--- a/toolbox/core/logs.py
+++ b/toolbox/core/logs.py
@@ -19,8 +19,12 @@ _DEFAULT_LOG_DIR = "/userdata/system/logs"
 # emulatorlauncher.py launch markers (format observed on Batocera v43):
 #   ... 'gameStart', '<system>', '<emulator>', '<core>', PosixPath('<rompath>')
 #   ... launch Exiting configgen with status <N>
+# The rompath is Python's repr of a PosixPath, so a path containing an
+# apostrophe (common in No-Intro names, e.g. "Assassin's Creed") is emitted with
+# DOUBLE quotes -- PosixPath("..."). Accept either quote style, or the launch is
+# invisible and the card reports the previous game's verdict.
 _GAMESTART = re.compile(
-    r"'gameStart',\s*'([^']*)',\s*'([^']*)',\s*'([^']*)',\s*PosixPath\('([^']*)'\)")
+    r"""'gameStart',\s*'([^']*)',\s*'([^']*)',\s*'([^']*)',\s*PosixPath\((['"])(.*?)\4\)""")
 _STATUS = re.compile(r"Exiting configgen with status (-?\d+)")
 
 # Substrings that mark a line as an error worth surfacing in the crash summary.
@@ -130,13 +134,13 @@ def parse_last_launch(stdout_text: str, stderr_text: str = "",
     matches = list(_GAMESTART.finditer(stdout_text))
     chosen = None
     for i in range(len(matches) - 1, -1, -1):
-        if os.path.basename(matches[i].group(4)) != ignore_basename:
+        if os.path.basename(matches[i].group(5)) != ignore_basename:
             chosen = i
             break
     if chosen is None:
         return None
     m = matches[chosen]
-    system, emulator, core, rompath = m.group(1), m.group(2), m.group(3), m.group(4)
+    system, emulator, core, rompath = m.group(1), m.group(2), m.group(3), m.group(5)
     game = os.path.basename(rompath) or rompath
     end = matches[chosen + 1].start() if chosen + 1 < len(matches) else len(stdout_text)
     window = stdout_text[m.end():end]

--- a/toolbox/core/perf.py
+++ b/toolbox/core/perf.py
@@ -16,8 +16,6 @@ write backs up `batocera.conf.bak-toolbox-*` first, mirroring the Shaders module
 from __future__ import annotations
 
 import re
-import time
-from pathlib import Path
 
 from . import config
 
@@ -94,16 +92,12 @@ def read_overclock(text: str) -> dict:
 
 
 def read_conf() -> str:
-    try:
-        return config.batocera_conf().read_text(encoding="utf-8")
-    except OSError:
-        return ""
+    """Read batocera.conf. Empty only when genuinely absent; a present-but-
+    unreadable conf RAISES so its snapshot is never rewritten over the real file
+    (see config.read_conf_text)."""
+    return config.read_conf_text()
 
 
 def write_conf(text: str) -> None:
-    """Back up batocera.conf (timestamped), then write the new text."""
-    conf = config.batocera_conf()
-    if conf.is_file():
-        bak = conf.with_name(f"batocera.conf.bak-toolbox-{time.strftime('%Y%m%d-%H%M%S')}")
-        bak.write_bytes(conf.read_bytes())
-    conf.write_text(text, encoding="utf-8")
+    """Back up (capped) batocera.conf, then write the new text atomically."""
+    config.write_batocera_conf(text)

--- a/toolbox/core/portmeta.py
+++ b/toolbox/core/portmeta.py
@@ -10,14 +10,14 @@ are left untouched.
 """
 from __future__ import annotations
 
-import os
 import sys
-import time
 import xml.etree.ElementTree as ET
 from pathlib import Path
 
+from . import config
+
 # How many gamelist.xml.bak-toolbox-* copies to keep (newest first).
-BACKUP_KEEP = 5
+BACKUP_KEEP = config.BACKUP_KEEP
 
 # Static metadata + media we ship for the Toolbox PORTS entry. Media paths are
 # gamelist-relative (./images/...), matching how Batocera stores them.
@@ -37,30 +37,11 @@ TOOLBOX_META = {
 }
 
 
-def prune_backups(path: Path | str, keep: int = BACKUP_KEEP) -> None:
-    """Keep only the newest `keep` `<name>.bak-toolbox-*` files beside `path`.
-
-    Backup names embed a sortable `YYYYMMDD-HHMMSS` stamp, so a name sort is
-    chronological. Older copies beyond `keep` are removed.
-    """
-    p = Path(path)
-    baks = sorted(p.parent.glob(f"{p.name}.bak-toolbox-*"), key=lambda b: b.name)
-    for old in baks[:-keep] if keep > 0 else baks:
-        old.unlink(missing_ok=True)
-
-
-def _backup(path: Path) -> None:
-    ts = time.strftime("%Y%m%d-%H%M%S")
-    path.with_name(f"{path.name}.bak-toolbox-{ts}").write_bytes(path.read_bytes())
-    prune_backups(path)
-
-
-def _write_atomic(tree: ET.ElementTree, path: Path) -> None:
-    """Write to a temp sibling then os.replace, so the gamelist is never seen
-    half-written (it's read by EmulationStation on boot)."""
-    tmp = path.with_name(f"{path.name}.tmp-toolbox")
-    tree.write(tmp, encoding="utf-8", xml_declaration=True)
-    os.replace(tmp, path)
+# Backup/atomic-write primitives live in config now (shared with perf/shaders/
+# library). Re-exported here so the module's public surface and tests are stable.
+prune_backups = config.prune_backups
+_backup = config.backup_file
+_write_atomic = config.atomic_write_tree
 
 
 def merge_port_entry(gamelist_path: Path | str, sh_relpath: str = "./Toolbox.sh",

--- a/toolbox/core/restore.py
+++ b/toolbox/core/restore.py
@@ -16,6 +16,7 @@ ok/failed accounting.
 """
 from __future__ import annotations
 
+import shlex
 import subprocess
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -90,16 +91,22 @@ def parse_remote_listing(text: str) -> list[str]:
     return [c for c in CATEGORIES if c in present]
 
 
-def list_remote_categories(backup_cfg: dict | None = None) -> list[str]:
+def list_remote_categories(backup_cfg: dict | None = None) -> list[str] | None:
     """SSH the NAS and return the categories whose backup path exists.
 
     Each category maps to a specific remote path (some nested, e.g.
     userdata/saves), so we test each path's existence rather than listing one
-    directory. Returns [] on any error.
+    directory.
+
+    Returns ``None`` when the NAS couldn't be REACHED (host down, timeout, auth
+    rejected: ssh exit 255 or a spawn error) so the UI can say "check the
+    connection" instead of "nothing to restore". A reached NAS with no backups
+    yet returns ``[]``. The per-path ``test`` chain's own exit code (0/1) is
+    normal and does not signal a connection error.
     """
     backup_cfg = backup_cfg or config.backup_config()
     dest = backup_cfg["dest"]
-    checks = " ; ".join(f'test -e "{dest}/{remote}" && echo {cat}'
+    checks = " ; ".join(f"test -e {shlex.quote(f'{dest}/{remote}')} && echo {cat}"
                         for cat, (remote, _local) in CATEGORIES.items())
     cmd = ["ssh", "-p", str(backup_cfg["port"]),
            "-o", "StrictHostKeyChecking=accept-new",
@@ -107,9 +114,9 @@ def list_remote_categories(backup_cfg: dict | None = None) -> list[str]:
     try:
         proc = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
     except (OSError, subprocess.SubprocessError):
-        return []
-    if proc.returncode != 0 and not proc.stdout:
-        return []
+        return None
+    if proc.returncode == 255:      # ssh's own "couldn't connect / auth failed"
+        return None
     return parse_remote_listing(proc.stdout or "")
 
 

--- a/toolbox/core/shaders.py
+++ b/toolbox/core/shaders.py
@@ -9,15 +9,12 @@ silent-fail trap (a typo'd preset name loads nothing, with no error).
 
 `enumerate_presets()` returns the valid values; `entries()` turns that flat list
 into a folder->preset browse tree; `get_renderer()`/`set_renderer()` read and
-rewrite batocera.conf, preserving every other line and stamping a one-time
-backup before the first edit.
+rewrite batocera.conf, preserving every other line and writing a capped,
+timestamped backup before each edit (atomic write, via config).
 """
 from __future__ import annotations
 
 import re
-import shutil
-import time
-from pathlib import Path
 
 from . import config
 
@@ -65,11 +62,10 @@ def entries(prefix: str = "", presets: list[str] | None = None) -> tuple[list[st
 
 
 def _read_conf_text() -> str:
-    p = config.batocera_conf()
-    try:
-        return p.read_text(encoding="utf-8")
-    except OSError:
-        return ""
+    """batocera.conf text. Empty only when genuinely absent; a present-but-
+    unreadable conf RAISES so its snapshot is never rewritten over the real
+    file (see config.read_conf_text)."""
+    return config.read_conf_text()
 
 
 def get_renderer(system: str, text: str | None = None) -> str | None:
@@ -94,7 +90,8 @@ def set_renderer(system: str, value: str, *, presets: list[str] | None = None) -
         if value not in valid:
             raise ValueError(f"not a valid shader preset: {value!r}")
 
-    conf = config.batocera_conf()
+    # Read the current conf up front. A failed read RAISES here (not "") so we
+    # never rewrite an empty file over a real, momentarily-unreadable conf.
     text = _read_conf_text()
     lines = text.splitlines()
     rx = re.compile(rf"^\s*{re.escape(system)}-renderer\.shader\s*=")
@@ -102,13 +99,5 @@ def set_renderer(system: str, value: str, *, presets: list[str] | None = None) -
     if value != INHERIT:
         kept.append(f"{key}={value}")
 
-    # One-time safety copy before the first edit.
-    bak = conf.with_name(conf.name + f".bak-toolbox-{time.strftime('%Y%m%d-%H%M%S')}")
-    try:
-        if conf.is_file():
-            shutil.copy2(conf, bak)
-    except OSError:
-        pass
-
-    conf.parent.mkdir(parents=True, exist_ok=True)
-    conf.write_text("\n".join(kept) + "\n", encoding="utf-8")
+    # Back up (capped) then write atomically, both handled by config.
+    config.write_batocera_conf("\n".join(kept) + "\n")

--- a/toolbox/ui/app.py
+++ b/toolbox/ui/app.py
@@ -6,7 +6,8 @@ UP / DOWN / CONFIRM / BACK / SELECT so keyboard and gamepad run identical code.
 
 Long jobs (rsync backup, the ROM walk) run on a worker thread and publish plain
 attributes that the main loop polls each frame; pygame calls stay on the main
-thread. The Shaders module is not wired up yet (see the package README).
+thread. A worker carries a generation id so a cancelled (abandoned) worker can't
+drive a later screen (see _spawn).
 """
 from __future__ import annotations
 
@@ -68,6 +69,7 @@ class App:
         self.input = controls.InputManager()
         self.setup_step = 0
         self.setup_return = "main"
+        self.setup_assigned: list[int] = []      # buttons taken so far this wizard
 
         self.running = True
         # First run with a gamepad and no saved mapping -> learn the buttons.
@@ -96,6 +98,10 @@ class App:
         self.audit_index = 0
         self.audit_prog = (0, 0, "")     # (done, total, system) for the loading bar
         self._worker: threading.Thread | None = None
+        # Bumped on every spawn and on cancel; a worker whose generation is no
+        # longer current can't set its done flag or report an error, so an
+        # abandoned (cancelled) worker never drives a later screen.
+        self._worker_gen = 0
         # Set by any worker that raises; surfaced (not swallowed) by _poll_workers
         # so a crashed job shows an error and returns to the menu instead of
         # leaving the loading screen frozen forever.
@@ -207,23 +213,33 @@ class App:
     def _cancel_loading(self) -> None:
         self.worker_error = ""
         self._clear_done_flags()
+        self._worker_gen += 1          # orphan the abandoned worker
         self.state, self.menu_index = "main", 0
 
     def _spawn(self, target, done_attr: str) -> None:
         """Run a worker body on a daemon thread, capturing any exception.
 
-        On an unhandled error we record it AND still set the done flag, so the
-        main loop leaves the loading screen (showing the error) instead of
+        Each spawn takes a generation id. A worker whose generation is no longer
+        current (the user cancelled, or started another load) sets neither its
+        done flag nor worker_error, so an abandoned slow worker (e.g. a hung NAS
+        listing) can't wake a later screen with stale results or a phantom error.
+        On success or unhandled error of the CURRENT worker the done flag is set,
+        so the loop leaves the loading screen (showing any error) instead of
         hanging on "please wait" forever — the exact trap that froze the audit.
         """
         self.worker_error = ""
+        self._worker_gen += 1
+        gen = self._worker_gen
 
         def runner() -> None:
             try:
                 target()
             except Exception as e:                       # surface, never freeze
-                self.worker_error = f"{type(e).__name__}: {e}"
-                setattr(self, done_attr, True)
+                if gen == self._worker_gen:
+                    self.worker_error = f"{type(e).__name__}: {e}"
+            finally:
+                if gen == self._worker_gen:
+                    setattr(self, done_attr, True)
 
         self._worker = threading.Thread(target=runner, daemon=True)
         self._worker.start()
@@ -261,10 +277,15 @@ class App:
         self.state = "audit_loading"
 
     def _enter_shaders(self) -> None:
+        try:
+            self.sh_conf = shaders._read_conf_text()
+        except (OSError, ValueError):
+            self._flash("Can't read batocera.conf.", "main",
+                        "the file exists but wouldn't read - not editing it")
+            return
         self.sh_presets = shaders.enumerate_presets()
         # Only systems we actually have games for: no point shading an empty one.
         self.sh_systems = config.list_systems_with_roms()
-        self.sh_conf = shaders._read_conf_text()
         self.state, self.menu_index = "shaders_systems", 0
 
     def _enter_bios_run(self) -> None:
@@ -293,7 +314,12 @@ class App:
         self.state = "library_loading"
 
     def _enter_perf(self) -> None:
-        self.perf_conf = perf.read_conf()
+        try:
+            self.perf_conf = perf.read_conf()
+        except (OSError, ValueError):
+            self._flash("Can't read batocera.conf.", "main",
+                        "the file exists but wouldn't read - not editing it")
+            return
         ra = perf.read_runahead(self.perf_conf)
         oc = perf.read_overclock(self.perf_conf)
         self.perf_rows = [("ra", s) for s in ra] + [("oc", s) for s in oc]
@@ -316,6 +342,7 @@ class App:
             self._flash("No gamepad detected.", "main", "Keyboard always works.")
             return
         self.setup_step = 0
+        self.setup_assigned = []
         self.setup_return = "main"
         self.state = "controller_setup"
 
@@ -330,8 +357,17 @@ class App:
             self._flash("Setup skipped (using keyboard).", self.setup_return)
             return
         if event.type == pygame.JOYBUTTONDOWN:
+            # Reject a button already bound to an earlier action: translate()
+            # returns the FIRST matching action, so a duplicate would make the
+            # later action (e.g. BACK) unreachable from the pad -- trapping the
+            # user in submenus with no keyboard.
+            if event.button in self.setup_assigned:
+                self._flash("That button is already used.", "controller_setup",
+                            "press a different button for this action")
+                return
             action_key = controls.SETUP_STEPS[self.setup_step][0]
             self.input.mapping[action_key] = event.button
+            self.setup_assigned.append(event.button)
             self.setup_step += 1
             if self.setup_step >= len(controls.SETUP_STEPS):
                 self.input.save_mapping()
@@ -402,7 +438,6 @@ class App:
         def cb(leg: str, pct: int) -> None:
             self.bk_leg, self.bk_pct = leg, pct
         self.bk_result = backup.run_backup(self.bk_tier, dry_run=self.backup_dryrun, on_progress=cb)
-        self.bk_done = True
 
     def draw_backup_progress(self) -> None:
         self._title("BACKING UP")
@@ -422,7 +457,6 @@ class App:
         # Drop empty systems (0 games) from the dashboard: no roms, nothing to show.
         rows = audit.audit_systems(on_progress=cb)
         self.audit_rows = [r for r in rows if r.games > 0]
-        self.audit_done = True
 
     def draw_audit_loading(self) -> None:
         self._title("ROM AUDIT")
@@ -497,7 +531,6 @@ class App:
         except OSError:
             conf_text = ""
         bios.annotate_cores(self.bios_all, conf_text)
-        self.bios_done = True
 
     def _bios_build_rows(self) -> None:
         if self.bios_show_all:
@@ -507,7 +540,11 @@ class App:
         # How many played systems we suppressed because their core needs no BIOS.
         self.bios_hidden = sum(1 for s in self.bios_all
                                if s.problems > 0 and s.system in self.bios_played and s.bios_free)
-        self.bios_index = 0
+        # Reset BOTH cursors together: the all/played toggle rebuilds (and can
+        # shrink) bios_rows, and on_bios copies menu_index into bios_index on the
+        # next CONFIRM. Leaving menu_index stale would index past the shorter list
+        # and crash draw_bios_detail with an IndexError.
+        self.bios_index = self.menu_index = 0
 
     def draw_bios_loading(self) -> None:
         self._title("BIOS CHECK")
@@ -592,6 +629,8 @@ class App:
         if not self.bios_rows:
             self.state = "bios"
             return
+        # Clamp: the all/played toggle can shrink bios_rows under the cursor.
+        self.bios_index = min(self.bios_index, len(self.bios_rows) - 1)
         sysb = self.bios_rows[self.bios_index]
         self._text(self.f_mid, sysb.system, int(self.H * 0.20), color=TEAL)
         if sysb.core:
@@ -614,8 +653,8 @@ class App:
     # RESTORE (pull a category back from the NAS; dry-run by default)
     # ===================================================================
     def _restore_list_thread(self) -> None:
+        # None = couldn't reach the NAS; [] = reached, nothing backed up yet.
         self.rs_cats = restore.list_remote_categories()
-        self.rs_listed = True
 
     def draw_restore_loading(self) -> None:
         self._title("RESTORE")
@@ -681,7 +720,6 @@ class App:
         def cb(leg: str, pct: int) -> None:
             self.rs_leg, self.rs_pct = leg, pct
         self.rs_result = restore.run_restore(self.rs_cat, dry_run=self.restore_dryrun, on_progress=cb)
-        self.rs_done = True
 
     def draw_restore_progress(self) -> None:
         self._title("RESTORING")
@@ -699,7 +737,6 @@ class App:
         # Build a hide plan per eligible system; keep only ones with work to do.
         plans = [library.plan_system(s) for s in library.eligible_systems()]
         self.lib_plans = [p for p in plans if p.hide or p.n_skipped]
-        self.lib_done = True
 
     def draw_library_loading(self) -> None:
         self._title("LIBRARY (1G1R)")
@@ -834,7 +871,6 @@ class App:
     def _library_apply_thread(self) -> None:
         p = self.lib_plans[self.lib_index]
         self.lib_result = library.apply_hides(p.system, p.hide)
-        self.lib_apply_done = True
 
     # --- Apply ALL systems in one pass --------------------------------------
     def on_library_confirm_all(self, action: str) -> None:
@@ -868,7 +904,6 @@ class App:
             agg.hidden += r.hidden
             agg.fav_protected += r.fav_protected
         self.lib_result = agg
-        self.lib_apply_done = True
 
     def draw_library_progress(self) -> None:
         self._title("APPLYING 1G1R")
@@ -900,7 +935,12 @@ class App:
                     text = perf.set_runahead(text, system, on)
                 else:
                     text = perf.set_overclock(text, system, on)
-            perf.write_conf(text)
+            try:
+                perf.write_conf(text)
+            except (OSError, ValueError):
+                self._flash("Couldn't save batocera.conf.", "main",
+                            "no changes written - the conf is untouched")
+                return
             self._flash("Performance settings saved.", "main",
                         "batocera.conf backed up  -  applies on next launch")
 
@@ -939,21 +979,21 @@ class App:
     # RETROACHIEVEMENTS: read-only profile + recent unlocks
     # ===================================================================
     def _cheevos_thread(self) -> None:
-        conf = perf.read_conf()
+        try:
+            conf = perf.read_conf()
+        except (OSError, ValueError):
+            conf = ""      # unreadable conf: treat as not configured, don't crash
         if not cheevos.enabled(conf):
             self.ch_error = "RetroAchievements is not enabled on this cabinet."
-            self.ch_done = True
             return
         user, token = cheevos.read_creds(conf)
         if not user:
             self.ch_error = "No RetroAchievements account configured."
-            self.ch_done = True
             return
         self.ch_summary = cheevos.fetch_summary(user, token)
         self.ch_recent = cheevos.fetch_recent(user, cheevos.web_api_key())
         if self.ch_summary is None and self.ch_recent is None:
             self.ch_error = "Could not reach RetroAchievements (check network)."
-        self.ch_done = True
 
     def draw_cheevos_loading(self) -> None:
         self._title("RETROACHIEVEMENTS")
@@ -1078,10 +1118,10 @@ class App:
     def _apply_shader(self, value: str | None) -> None:
         try:
             shaders.set_renderer(self.sh_system, value, presets=self.sh_presets)
+            self.sh_conf = shaders._read_conf_text()
         except (ValueError, OSError) as e:
             self._flash(f"Failed: {e}", "shaders_systems")
             return
-        self.sh_conf = shaders._read_conf_text()
         if value == shaders.INHERIT:
             self._flash(f"{self.sh_system}: cleared (inherits global)", "shaders_systems")
         else:
@@ -1143,7 +1183,11 @@ class App:
         elif self.state == "restore_loading" and self.rs_listed:
             self.state, self.menu_index = "restore", 0
             self.rs_listed = False
-            if not self.rs_cats:
+            if self.rs_cats is None:
+                self.rs_cats = []
+                self._flash("Couldn't reach the NAS.", "main",
+                            "check the host / SSH key / that it's powered on")
+            elif not self.rs_cats:
                 self._flash("Nothing on the NAS to restore yet.", "main",
                             "run a Backup first")
         elif self.state == "restore_progress" and self.rs_done:


### PR DESCRIPTION
Addresses the correctness/robustness findings from a review pass. The dominant theme was unguarded reads/writes of `batocera.conf` and `gamelist.xml` (the files the OS and EmulationStation parse at boot), fixed at one depth: shared atomic-write + capped-backup + fail-loud-read helpers in `config.py`, now used by perf, shaders, library, and portmeta instead of four hand-rolled copies.

## Data loss / corruption
- **conf wipe:** `config.read_conf_text` raises on a present-but-unreadable conf instead of returning `""` (that empty string was rewritten back over the real file). `shaders.set_renderer` / `perf.write_conf` now use it, write atomically, and cap backups (were unbounded).
- **gamelist:** `library.apply_hides` writes atomically (was truncate-in-place, corruptible by a power cut) + capped backup; `plan_system` excludes already-hidden variants so 1G1R converges to "already deduped" instead of re-listing them every run.
- **rsync injection:** the user dest is `shlex.quote`d in the remote `--rsync-path` (was shell-injectable / space-splittable). The "everything"-tier roms exclude is anchored to `/roms/` so nested `roms/` dirs aren't dropped from the full backup.
- **settings wipe:** `install.sh` `write_settings` merges into `settings.json` instead of overwriting it (was deleting `retroachievements.web_api_key` on every `--config` re-run).

## Crashes
- perf/shaders UI guard the conf read/write so an `OSError` no longer escapes the event loop and kills the fullscreen app.
- BIOS all/played toggle resets `menu_index` with the rebuilt rows and clamps the detail index, so shrink-then-confirm can't `IndexError` the TUI.

## False signals
- `bios.run_check` raises when `batocera-systems` can't run (was returning `[]`, rendered as a green "no problems" for a check that never happened).
- `restore.list_remote_categories` returns `None` on a connection failure vs `[]` for reached-but-empty; the UI now says "couldn't reach the NAS" instead of "nothing to restore".
- logs accept a double-quoted `PosixPath`, so a ROM name with an apostrophe (e.g. `Assassin's Creed`) is no longer invisible to the crash-log card.
- Worker generation guard: a cancelled/abandoned worker can't set a done flag or report an error onto a later screen.
- Controller wizard rejects a button already bound to an earlier action, so a duplicate can't make BACK unreachable from the gamepad.

## Tests
+17 selftest checks covering the changed contracts (**215 OK, 0 NO**). The three UI-layer fixes (BIOS shrink, worker generation guard, duplicate-button) verified with a headless pygame stub. Stale module docstrings refreshed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)